### PR TITLE
feat: Use current image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,27 @@ Example `bin/release_image` script:
 ```rb
 #!/usr/bin/env ruby
 
-require 'dotenv/load'
+require "dotenv/load"
+require "optparse"
 require "colorize"
 require "release_image"
 
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
+
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/release_image [options] version [date]"
+
+  opts.on("--skip-download", "Skip downloading a random image and use a previously downloaded image instead.") do
+    options[:skip_download] = true
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
 
 # Get api key at:
 # https://unsplash.com/oauth/applications
@@ -53,7 +69,17 @@ date    = ARGV[1]
 
 abort("Please provide a release version".red) unless version
 
-puts ReleaseImage.generate(version: version, date: date).green
+puts ReleaseImage.generate(version: version, date: date, skip_download: options[:skip_download]).green
+```
+
+### Use existing image
+
+Sometimes you may want to skip downloading a random image and use a previously downloaded image instead. This can be
+achieved by setting the `skip_download` option to `true`. Image is downloaded by default and saved to the `folder_path`
+directory as `image.jpg`.
+
+```rb
+ReleaseImage.generate(version: version, date: date, skip_download: true)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ APP_ROOT = File.expand_path("..", __dir__)
 options = {}
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: bin/release_image [options] version [date]"
+  opts.banner = "Usage: bin/release_image version [date] [options]"
 
   opts.on("--skip-download", "Skip downloading a random image and use a previously downloaded image instead.") do
     options[:skip_download] = true

--- a/lib/release_image.rb
+++ b/lib/release_image.rb
@@ -25,9 +25,11 @@ module ReleaseImage
   class Generator
     BASE_URL = "https://api.unsplash.com/photos/random"
 
-    def initialize(version:, date: nil)
+    def initialize(version:, date: nil, skip_download: false)
       @version = version
       @date    = date ? Date.parse(date) : Date.today
+
+      @skip_download = skip_download
 
       @folder_path = ReleaseImage.config.folder_path
       @logo_path   = ReleaseImage.config.logo_path
@@ -38,7 +40,7 @@ module ReleaseImage
 
     def generate
       create_folder
-      download_image
+      download_image unless @skip_download
       create_release_image
     end
 
@@ -138,7 +140,7 @@ module ReleaseImage
     @config ||= ReleaseImage::Config.new
   end
 
-  def self.generate(version:, date: nil)
-    Generator.new(version: version, date: date).generate
+  def self.generate(version:, date: nil, skip_download: false)
+    Generator.new(version: version, date: date, skip_download: skip_download).generate
   end
 end


### PR DESCRIPTION
Sometimes you may want to skip downloading a random image and use a previously downloaded image instead. 
This can be achieved by setting the `skip_download` option to `true`. 